### PR TITLE
Added exclude TV as config option

### DIFF
--- a/core/components/googlesitemap/model/googlesitemap/googlesitemap.class.php
+++ b/core/components/googlesitemap/model/googlesitemap/googlesitemap.class.php
@@ -60,6 +60,7 @@ class GoogleSiteMap {
             'excludeChildrenOf' => '',
             'showHidden' => false,
             'priorityTV' => 0,
+            'excludeTV' => '',
         ),$config);
     }
 
@@ -97,6 +98,11 @@ class GoogleSiteMap {
             }
             if (empty($this->config['showHidden'])) {
                 $canParse = $canParse && (!$child->get('hidemenu') || $child->get('class_key') == 'Article');
+            }
+
+            /* if using an exclude tv */
+            if (!empty($this->config['excludeTV'])) {
+                $canParse = $canParse && ($child->getTVValue($this->config['excludeTV']) != '1');
             }
 
             if ($canParse) {


### PR DESCRIPTION
Added config option for excludeTV similar to Evo functionality (http://wiki.modxcms.com/index.php/SiteMap:_Google_sitemaps_in_MODx). If value of tv is 1 then it will be excluded (expecting TV to be a radio with 1 being to exclude resource).
