### PR TITLE
add resource id as placeholder

### DIFF
--- a/core/components/googlesitemap/model/googlesitemap/googlesitemap.class.php
+++ b/core/components/googlesitemap/model/googlesitemap/googlesitemap.class.php
@@ -128,6 +128,7 @@ class GoogleSiteMap {
                 }
                 /* add item to output */
                 $output .= $this->getChunk($this->config['itemTpl'],array(
+                    'id' => $id,
                     'url' => $url,
                     'date' => $date,
                     'update' => $update,


### PR DESCRIPTION
added the resource id as placeholder to the itemTpl. I currently need this to build a sitemap for a multilingual website (where I need the ID to find the translated resources). Should be useful for others too.
